### PR TITLE
Use post-summary include renamed in Chirpy 7.5

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -83,7 +83,7 @@ refactor: true
             <h1 class="card-title my-2 mt-md-0">{{ post.title }}</h1>
 
             <div class="card-text content mt-0 mb-3">
-              <p>{% include post-description.html %}</p>
+              <p>{% include post-summary.html %}</p>
             </div>
 
             <div class="post-meta flex-grow-1 d-flex align-items-end">


### PR DESCRIPTION
Chirpy 7.5.0 renamed its post-description.html include to post-summary.html; the customized home layout still referenced the old name, breaking the Pages build.